### PR TITLE
feat: add office color palette

### DIFF
--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -6,7 +6,14 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'office-blue': '#1A4E8A',      // pick exact shade
+        'office-blue-dark': '#123963',
+        'office-red': '#B3261E',
+        'office-red-dark': '#7A1A15'
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- define office brand colors in Tailwind config for reuse

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ac19f01c10832d8aaa9ea7d1db23e4