### PR TITLE
refactor: update color scheme

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -17,13 +17,13 @@ export default function DataTable<T extends object>({
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm">
         <thead>
-          <tr className="text-left bg-gray-50">
+          <tr className="text-left bg-office-blue text-white">
             {columns.map((c) => <th key={String(c.key)} className="px-3 py-2 font-medium">{c.label}</th>)}
           </tr>
         </thead>
         <tbody>
           {rows.length === 0 && (
-            <tr><td className="px-3 py-6 text-gray-500" colSpan={columns.length}>{empty}</td></tr>
+            <tr><td className="px-3 py-6 text-office-blue-dark" colSpan={columns.length}>{empty}</td></tr>
           )}
           {rows.map((r, i) => (
             <tr key={i} className="border-t">

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -17,7 +17,7 @@ export default function Toast() {
   if (!msg) return null;
   return (
     <div className="fixed bottom-6 inset-x-0 grid place-items-center pointer-events-none">
-      <div className="pointer-events-auto bg-gray-900 text-white px-4 py-2 rounded-xl shadow">{msg}</div>
+      <div className="pointer-events-auto bg-office-blue-dark text-white px-4 py-2 rounded-xl shadow">{msg}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use office blue for data tables and empty state messaging
- switch toast background to dark office blue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1aa34e90832d962ab7d0563c84ad