### PR TITLE
style: apply office blue theme with red accents

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,13 +8,18 @@ export default function Header() {
   const { state, logout } = useAuth();
   const me = state.me;
   return (
-    <header className="sticky top-0 z-10 bg-white border-b">
+    <header className="sticky top-0 z-10 bg-office-blue border-b border-red-500 text-white">
       <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
         <div className="font-semibold">KidneyTx Pharma Portal</div>
         <div className="flex items-center gap-3">
           {me && <RoleBadge role={me.role} />}
-          <span className="text-sm text-gray-600">{me?.full_name ?? me?.phone}</span>
-          <button onClick={logout} className="text-sm px-3 py-1.5 border rounded-lg hover:bg-gray-50">Logout</button>
+          <span className="text-sm text-gray-200">{me?.full_name ?? me?.phone}</span>
+          <button
+            onClick={logout}
+            className="text-sm px-3 py-1.5 border border-red-500 text-red-500 rounded-lg hover:bg-office-blue-dark hover:text-white"
+          >
+            Logout
+          </button>
         </div>
       </div>
     </header>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,9 +7,9 @@ import { NavLink } from "react-router-dom";
 type Item = { label: string; to: string };
 export default function Sidebar({ title, items }: { title: string; items: Item[] }) {
   return (
-    <aside className="w-[var(--sidebar-w)] min-h-screen bg-white border-r">
-      <div className="p-4 border-b">
-        <h1 className="font-bold text-xl">{title}</h1>
+    <aside className="w-[var(--sidebar-w)] min-h-screen bg-office-blue text-white border-r border-red-500">
+      <div className="p-4 border-b border-red-500">
+        <h1 className="font-bold text-xl text-red-200">{title}</h1>
       </div>
       <nav className="p-2 flex flex-col gap-1">
         {items.map((it) => (
@@ -17,7 +17,7 @@ export default function Sidebar({ title, items }: { title: string; items: Item[]
             key={it.to}
             to={it.to}
             className={({ isActive }) =>
-              `px-3 py-2 rounded-lg hover:bg-gray-100 ${isActive ? "bg-gray-100 font-semibold" : ""}`
+              `px-3 py-2 rounded-lg hover:bg-office-blue-dark ${isActive ? "bg-office-blue-dark font-semibold text-red-200" : ""}`
             }
           >
             {it.label}


### PR DESCRIPTION
## Summary
- use office blue background for Header with red logout button accent and hover styling
- update Sidebar to office blue scheme with red borders and active link text

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac1a9c16ec832d8d4d1811baea72a8