### PR TITLE
feat: update primary button color scheme

### DIFF
--- a/frontend/src/components/Form.tsx
+++ b/frontend/src/components/Form.tsx
@@ -26,7 +26,7 @@ export const Button = ({ children, ...rest }: React.ButtonHTMLAttributes<HTMLBut
 );
 
 export const Primary = ({ children, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-  <button {...rest} className={`px-4 py-2 rounded-xl shadow bg-blue-600 text-white hover:bg-blue-700 text-sm ${rest.className ?? ""}`}>
+  <button {...rest} className={`px-4 py-2 rounded-xl shadow bg-office-blue text-white hover:bg-office-blue-dark text-sm ${rest.className ?? ""}`}>
     {children}
   </button>
 );


### PR DESCRIPTION
## Summary
- use `bg-office-blue` for Primary button background
- apply `hover:bg-office-blue-dark` on hover

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1a97ae18832d8a644e1a721effff