### PR TITLE
feat: apply office color tokens to global layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>KidneyTx Pharma Portal</title>
   </head>
-  <body class="bg-gray-50 text-gray-900">
+  <body class="bg-office-blue text-office-red-dark">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,5 +4,5 @@
 
 /* App globals */
 body {
-  @apply bg-gray-50 text-gray-900;
+  @apply bg-office-blue text-office-red-dark;
 }


### PR DESCRIPTION
## Summary
- switch index.html body to office-blue & office-red-dark tokens
- update global body styles in index.css to use office color tokens

## Testing
- `npm run build` *(fails: The `bg-office-blue` class does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a904070832d82b827315f3fedad