### PR TITLE
feat: apply office brand colors to role badge

### DIFF
--- a/frontend/src/components/RoleBadge.tsx
+++ b/frontend/src/components/RoleBadge.tsx
@@ -3,9 +3,9 @@
  */
 export default function RoleBadge({ role }: { role: string }) {
   const color =
-    role === "ADMIN" ? "bg-purple-100 text-purple-700" :
-    role === "REGIONAL_MANAGER" ? "bg-emerald-100 text-emerald-700" :
-    role === "BRANCH_MANAGER" ? "bg-amber-100 text-amber-700" :
-    "bg-sky-100 text-sky-700";
+    role === "ADMIN" ? "bg-office-blue-100 text-office-blue-700" :
+    role === "REGIONAL_MANAGER" ? "bg-office-red-100 text-office-red-700" :
+    role === "BRANCH_MANAGER" ? "bg-office-red-50 text-office-red-700" :
+    "bg-office-blue-50 text-office-blue-700";
   return <span className={`text-xs px-2 py-1 rounded ${color}`}>{role}</span>;
 }


### PR DESCRIPTION
## Summary
- use office-blue for admin and default roles
- use office-red tones for manager roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1a9fc97c832dbbb941e33ca3b4c8